### PR TITLE
DAM-5913 Bump postgres docker version

### DIFF
--- a/Marketing_Campaign/postgres-docker-compose.yml
+++ b/Marketing_Campaign/postgres-docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - "5432:5432"
 
   kensu_load_data_with_pandas_v1:
-    image: vidmasze/kensu-dbt-postgres:dev2
+    image: vidmasze/kensu-dbt-postgres:dev3
     environment:
       CONF_FILE: "/kensu-dbt-example/conf.custom.ini"
     volumes:
@@ -22,7 +22,7 @@ services:
       - mypostgres
 
   kensu_load_data_with_pandas_v2:
-    image: vidmasze/kensu-dbt-postgres:dev2
+    image: vidmasze/kensu-dbt-postgres:dev3
     environment:
       CONF_FILE: "/kensu-dbt-example/conf.custom.ini"
     volumes:
@@ -34,7 +34,7 @@ services:
       - mypostgres
 
   kensu_run_dbt_postgres:
-    image: vidmasze/kensu-dbt-postgres:dev2
+    image: vidmasze/kensu-dbt-postgres:dev3
     environment:
       CONF_FILE: "/kensu-dbt-example/conf.custom.ini"
       DBT_CURRENT_PROJECT_DIR: "/kensu-dbt-example/dbt-projects/example_marketing"


### PR DESCRIPTION
Use the latest docker version of the dbt-postgres image

* Make the examples compatible with latest kensu-py lib which itself will work with the latest modules' release 22.07.x